### PR TITLE
Remove documentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ By default, index name will be inferred from your class name, you can set it exp
 ```php
 class Article {
     protected static $indexName = 'article-production';
-    protected static $documentType = 'post';
 }
 ```
 
@@ -338,7 +337,6 @@ Alternately, you can set them using the following static methods:
 
 ```php
 Article::indexName('article-production');
-Article::documentType('post');
 ```
 
 ## Updating the Documents in the Index

--- a/src/Indexing.php
+++ b/src/Indexing.php
@@ -103,7 +103,7 @@ trait Indexing
     public function mappings($options = [], callable $callable = null)
     {
         if (empty($this->mapping)) {
-            $this->mapping = new Mappings($this->documentType());
+            $this->mapping = new Mappings();
         }
 
         if (! empty($options)) {

--- a/src/OpenSearchModel.php
+++ b/src/OpenSearchModel.php
@@ -16,7 +16,6 @@ class OpenSearch extends GetOrSet
 
         $attributes = [
             'client' => app('opensearch'),
-            'documentType' => isset($class::$documentType) ? $class::$documentType : str_slug($name),
             'indexName' => isset($class::$indexName) ? $class::$indexName : str_slug(str_plural($name)),
         ];
 
@@ -72,11 +71,6 @@ trait OpenSearchModel
         $result = static::getOrSet('indexName', func_get_args());
 
         return $result;
-    }
-
-    public static function documentType()
-    {
-        return static::getOrSet('documentType', func_get_args());
     }
 
     public static function getDocument($primaryKey, $options = [])

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -32,17 +32,6 @@ class ProxyTest extends TestCase
         $this->assertSame('foobar', ProxyTestModel::opensearch()->client());
     }
 
-    public function testGetDocumentType()
-    {
-        $this->assertEquals('proxy-test-model', ProxyTestModel::documentType());
-    }
-
-    public function testSetDocumentType()
-    {
-        ProxyTestModel::documentType('thingybob');
-        $this->assertEquals('thingybob', ProxyTestModel::documentType());
-    }
-
     public function testGetIndexName()
     {
         $this->assertEquals('proxy-test-models', ProxyTestModel::indexName());
@@ -57,10 +46,5 @@ class ProxyTest extends TestCase
     public function testGetIndexNameWithProperty()
     {
         $this->assertEquals('foo', ProxyTestModelWithProperties::indexName());
-    }
-
-    public function testGetDocumentTypeWithProperty()
-    {
-        $this->assertEquals('bar', ProxyTestModelWithProperties::documentType());
     }
 }


### PR DESCRIPTION
Recent versions of Elasticsearch and OpenSearch do not support _type or documentType in the payload.